### PR TITLE
disable padding check for llc packets

### DIFF
--- a/ryu/lib/packet/llc.py
+++ b/ryu/lib/packet/llc.py
@@ -250,7 +250,7 @@ class ControlFormatS(stringify.StringifyMixin):
         (control,) = struct.unpack_from(cls._PACK_STR, buf)
 
         assert (control >> 8) & 0b11 == cls.TYPE
-        assert (control >> 12) & 0b1111 == 0
+        #assert (control >> 12) & 0b1111 == 0
 
         supervisory_function = (control >> 10) & 0b11
         pf_bit = (control >> 8) & 0b1


### PR DESCRIPTION
the llc padding check causes an exception when android or iOS devices are used (dhcp).